### PR TITLE
package:curl bumps to 7.59.0

### DIFF
--- a/package/network/utils/curl/Makefile
+++ b/package/network/utils/curl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=7.58.0
+PKG_VERSION:=7.59.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \
 	http://curl.mirror.anstey.ca/ \
 	http://curl.askapache.com/download/ \
 	https://curl.haxx.se/download/
-PKG_HASH:=1cb081f97807c01e3ed747b6e1c9fee7a01cb10048f1cd0b5f56cfe0209de731
+PKG_HASH:=b5920ffd6a8c95585fb95070e0ced38322790cb335c39d0dab852d12e157b5a0
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION

- [x] Compile tested: (x86_64, Ubuntu 16.04 on Win 10 WSL, 16.04)
- [x] Run tested: (mips32r2, MIPS 1004kc V2.15, LEDE 17.01.4, tests done)
