### PR TITLE
Add wg-quick to wireguard-tools package

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -52,8 +52,10 @@ define Package/wireguard-tools/description
 endef
 
 define Package/wireguard-tools/install
+	$(MAKE) -C $(PKG_BUILD_DIR)/src DESTDIR=$(1)/opt WITH_WGQUICK=yes \
+		WITH_SYSTEMDUNITS=yes WITH_BASHCOMPLETION=no install
 	$(INSTALL_DIR) $(1)/opt/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wg $(1)/opt/bin/
+	ln -s /opt/usr/bin/wg $(1)/opt/bin/wg
 	$(INSTALL_BIN) ./files/wireguard_watchdog $(1)/opt/bin/
 	$(INSTALL_DIR) $(1)/opt/lib/netifd/proto/
 	$(INSTALL_BIN) ./files/wireguard.sh $(1)/opt/lib/netifd/proto/


### PR DESCRIPTION
As far as I could tell, `wireguard-tools` isn't any feeds, but if there's a more appropriate place to send this PR, let me know and I'd be happy to send my PR there instead.


This pull request adds the `wg-quick` bash program to the `wireguard-tools` package. It also adds systemd unit files for wg-quick. I believe that OpenWRT had these disabled simply because it does not use systemd. I'm assuming that embedded systems that don't use systemd will just ignore the unit files.

I added a symlink from `/opt/bin/wg` to `/opt/usr/bin/wg`, which is where wireguard-tools' `make install` puts the program. Other than that, this change only adds new files, so it should be backwards compatible.

Should I also bump the `PKG_RELEASE`? 

---

- [x] Compile tested: x86_64 Ubuntu 20.04,  target-arm_cortex-a9-glibc-2.27_eabi/linux-armv7-3.2/wireguard-tools-1.0.20200827
- [x] Run tested: armv7l, reMarkable 2.0, connected to the [demo server using `client.sh`](https://www.wireguard.com/quickstart/), connected to another computer using wg-quick using systemd