### PR TITLE
Port uci to entware

### DIFF
--- a/package/system/uci/Makefile
+++ b/package/system/uci/Makefile
@@ -50,36 +50,36 @@ define Package/libuci-lua
   TITLE:=Lua plugin for UCI
 endef
 
-TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include
-TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib
+TARGET_CFLAGS += -I$(STAGING_DIR)/opt/include
+TARGET_LDFLAGS += -L$(STAGING_DIR)/opt/lib
 
 CMAKE_OPTIONS += \
-	-DLUAPATH=/usr/lib/lua \
+	-DLUAPATH=/opt/lib/lua \
 	$(if $(DEBUG),-DUCI_DEBUG=ON)
 
 define Package/libuci/install
-	$(INSTALL_DIR) $(1)/lib
-	$(CP) $(PKG_BUILD_DIR)/libuci.so* $(1)/lib/
+	$(INSTALL_DIR) $(1)/opt/lib
+	$(CP) $(PKG_BUILD_DIR)/libuci.so* $(1)/opt/lib/
 endef
 
 define Package/libuci-lua/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua
-	$(CP) $(PKG_BUILD_DIR)/lua/uci.so $(1)/usr/lib/lua/
+	$(INSTALL_DIR) $(1)/opt/lib/lua
+	$(CP) $(PKG_BUILD_DIR)/lua/uci.so $(1)/opt/lib/lua/
 endef
 
 define Package/uci/install
-	$(INSTALL_DIR) $(1)/etc/uci-defaults
-	$(INSTALL_DIR) $(1)/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uci $(1)/sbin/
-	$(CP) ./files/* $(1)/
+	$(INSTALL_DIR) $(1)/opt/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/opt/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uci $(1)/opt/sbin/
+	$(CP) ./files/* $(1)/opt
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_BUILD_DIR)/uci{,_config,_blob,map}.h $(1)/usr/include
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_BUILD_DIR)/libuci.so* $(1)/usr/lib
-	$(CP) $(PKG_BUILD_DIR)/libucimap.a $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/opt/include
+	$(CP) $(PKG_BUILD_DIR)/uci{,_config,_blob,map}.h $(1)/opt/include
+	$(INSTALL_DIR) $(1)/opt/lib
+	$(CP) $(PKG_BUILD_DIR)/libuci.so* $(1)/opt/lib
+	$(CP) $(PKG_BUILD_DIR)/libucimap.a $(1)/opt/lib
 endef
 
 $(eval $(call BuildPackage,libuci))

--- a/package/system/uci/patches/100-change-config-dir-to-opt.patch
+++ b/package/system/uci/patches/100-change-config-dir-to-opt.patch
@@ -1,0 +1,13 @@
+index b385e2b..8c98e8b 100644
+--- a/uci.h
++++ b/uci.h
+@@ -36,7 +36,7 @@ extern "C" {
+ #include <stdint.h>
+ #include <stddef.h>
+
+-#define UCI_CONFDIR "/etc/config"
++#define UCI_CONFDIR "/opt/etc/config"
+ #define UCI_SAVEDIR "/tmp/.uci"
+ #define UCI_DIRMODE 0700
+ #define UCI_FILEMODE 0600
+


### PR DESCRIPTION
- [x] Compile tested: armv7-2.6
- [x] Run tested: FreshTomato 2021.8 (Netgear R7000)

This ports the uci configuration system to make it available for other firmware and opens up the use of all tools that depend on the uci system. Configuration path changed to /opt/etc/config and install paths prefixed with /opt

Tested and working.
Use case: 

Allowing use of openwrt scripts that depend on uci such as cake (for kernels that have it) or something like https://github.com/sqm-autorate/sqm-autorate/tree/testing/lua-threads which stores its config in the uci system.

Thank you for considering my PR.