### PR TITLE
Fix sdk bundling (make target/sdk/compile)

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -18,7 +18,7 @@ SDK_BUILD_DIR:=$(BUILD_DIR)/$(SDK_NAME)
 
 STAGING_SUBDIR_HOST := staging_dir/host
 STAGING_SUBDIR_TARGET := staging_dir/$(TARGET_DIR_NAME)
-STAGING_SUBDIR_TOOLCHAIN := staging_dir/toolchain-$(ARCH)$(ARCH_SUFFIX)_gcc-$(GCCV)_$(LIBC)$(if $(CONFIG_arm),_eabi)
+STAGING_SUBDIR_TOOLCHAIN := staging_dir/$(TOOLCHAIN_DIR_NAME)
 
 BUNDLER_PATH := $(subst $(space),:,$(filter-out $(TOPDIR)/%,$(subst :,$(space),$(PATH))))
 BUNDLER_COMMAND := PATH=$(BUNDLER_PATH) $(XARGS) $(SCRIPT_DIR)/bundle-libraries.sh $(SDK_BUILD_DIR)/$(STAGING_SUBDIR_HOST)

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -158,14 +158,10 @@ $(BIN_DIR)/$(SDK_NAME).tar.zst: clean
 		./files/include/prepare.mk \
 		./files/README.md \
 		$(SDK_BUILD_DIR)/
-	mkdir -p $(SDK_BUILD_DIR)/package/kernel
 	$(CP) \
 		$(TOPDIR)/package/Makefile \
 		$(TOPDIR)/package/libs/toolchain \
 		$(SDK_BUILD_DIR)/package/
-	$(CP) \
-		$(TOPDIR)/package/kernel/linux \
-		$(SDK_BUILD_DIR)/package/kernel/
 
 	-rm -rf $(SDK_BUILD_DIR)/$(STAGING_SUBDIR_HOST)/.prereq-build
 	-rm -rf $(SDK_BUILD_DIR)/$(STAGING_SUBDIR_HOST)/doc


### PR DESCRIPTION
Fixes two different issues with sdk bundling via `make target/sdk/compile`:

- Entware doesn't have package/kernel and because of it sdk compile fails
- sync STAGING_SUBDIR_TOOLCHAIN with OpenWrt (solves issues with absence LIBC version suffix for toolchain dir)

After these changes sdk bundling will work and will packed to tar.zst archive which can be used to build packages faster (just like OpenWrt do)

I create repo automatic builds of SDK (see https://github.com/ownik/entware-sdk). I use these patches there for correct building of sdk.

Also i create github action, which build packages based on these sdk builds. (see https://github.com/ownik/gh-action-entware-sdk). It just similar like official [openwrt/gh-action-sdk](https://github.com/openwrt/gh-action-sdk)

BTW, maybe you could mention these things in your wiki, it could be useful for some people. Or you can build sdk on your pipelines and publish it on official website/repo (like OpenWrt do)


